### PR TITLE
[bug] Declare proper async for charger

### DIFF
--- a/custom_components/evse_load_balancer/chargers/charger.py
+++ b/custom_components/evse_load_balancer/chargers/charger.py
@@ -42,7 +42,7 @@ class Charger(ABC):
         return self.config_entry.entry_id
 
     @abstractmethod
-    def async_setup(self) -> None:
+    async def async_setup(self) -> None:
         """Set up charger."""
 
     @abstractmethod

--- a/custom_components/evse_load_balancer/chargers/easee_charger.py
+++ b/custom_components/evse_load_balancer/chargers/easee_charger.py
@@ -63,7 +63,7 @@ class EaseeCharger(HaDevice, Charger):
             id_domain == CHARGER_DOMAIN_EASEE for id_domain, _ in device.identifiers
         )
 
-    def async_setup(self) -> None:
+    async def async_setup(self) -> None:
         """Set up the charger."""
 
     def set_phase_mode(self, mode: PhaseMode, _phase: Phase | None = None) -> None:
@@ -161,4 +161,3 @@ class EaseeCharger(HaDevice, Charger):
 
     async def async_unload(self) -> None:
         """Unload the Easee charger."""
-        # No specific unload logic for Easee charger

--- a/custom_components/evse_load_balancer/chargers/zaptec_charger.py
+++ b/custom_components/evse_load_balancer/chargers/zaptec_charger.py
@@ -162,4 +162,3 @@ class ZaptecCharger(HaDevice, Charger):
 
     async def async_unload(self) -> None:
         """Unload the charger."""
-        # No specific unload logic


### PR DESCRIPTION
Resolves issue where charger is not declaring async_setup as `async` causing an error at bootstrap. 