### PR TITLE
[bug][#30] Retrieve device entry upon request

### DIFF
--- a/custom_components/evse_load_balancer/coordinator.py
+++ b/custom_components/evse_load_balancer/coordinator.py
@@ -104,10 +104,11 @@ class EVSELoadBalancerCoordinator:
             identifiers={(DOMAIN, self.config_entry.entry_id)}
         )
         if device is None:
-            _LOGGER.warning(
+            msg = (
                 "Device entry for EVSE Load Balancer not found. "
                 "This should not happen, please report this issue."
             )
+            raise RuntimeError(msg)
         return device
 
     async def _handle_options_update(


### PR DESCRIPTION
Device is not registered during setup, causing an error (#30) when the device is requested in the coordinator's constructor. 
Moving this into a cached property allows the device entry to be initialised when it's actually needed. 