### PR TITLE
[#60] Resolve non-increasing charger current 

### DIFF
--- a/custom_components/evse_load_balancer/chargers/amina_charger.py
+++ b/custom_components/evse_load_balancer/chargers/amina_charger.py
@@ -134,6 +134,10 @@ class AminaCharger(Zigbee2Mqtt, Charger):
         """Return whether the car is connected."""
         return bool(self._state_cache.get(AminaPropertyMap.EvConnected, False))
 
+    def is_charging(self) -> bool:
+        """Return whether the car is charging."""
+        return bool(self._state_cache.get(AminaPropertyMap.Charging, False))
+
     def can_charge(self) -> bool:
         """Return if car is connected and accepting charge."""
         if not self.car_connected():

--- a/custom_components/evse_load_balancer/chargers/charger.py
+++ b/custom_components/evse_load_balancer/chargers/charger.py
@@ -41,6 +41,16 @@ class Charger(ABC):
         """Return the unique ID of the charger."""
         return self.config_entry.entry_id
 
+    @property
+    def current_change_settle_time(self) -> int:
+        """
+        Current change settle time.
+
+        Return the time in seconds to wait after a current change
+        before requesting new limits change.
+        """
+        return 15
+
     @abstractmethod
     async def async_setup(self) -> None:
         """Set up charger."""
@@ -89,6 +99,10 @@ class Charger(ABC):
     @abstractmethod
     def can_charge(self) -> bool:
         """Return whether the car is connected and charging or accepting charge."""
+
+    @abstractmethod
+    def is_charging(self) -> bool:
+        """Return whether the car is actively charging."""
 
     @abstractmethod
     async def async_unload(self) -> None:

--- a/custom_components/evse_load_balancer/chargers/easee_charger.py
+++ b/custom_components/evse_load_balancer/chargers/easee_charger.py
@@ -136,10 +136,9 @@ class EaseeCharger(HaDevice, Charger):
         return True
 
     def _get_status(self) -> str | None:
-        return EaseeStatusMap.Charging
-        # return self._get_entity_state_by_translation_key(
-        #     EaseeEntityMap.Status,
-        # ) TODO(Dirk): Re-enable once we can test with a real charger
+        return self._get_entity_state_by_translation_key(
+            EaseeEntityMap.Status,
+        )
 
     def car_connected(self) -> bool:
         """See abstract Charger class for correct implementation of this method."""

--- a/custom_components/evse_load_balancer/chargers/easee_charger.py
+++ b/custom_components/evse_load_balancer/chargers/easee_charger.py
@@ -136,9 +136,10 @@ class EaseeCharger(HaDevice, Charger):
         return True
 
     def _get_status(self) -> str | None:
-        return self._get_entity_state_by_translation_key(
-            EaseeEntityMap.Status,
-        )
+        return EaseeStatusMap.Charging
+        # return self._get_entity_state_by_translation_key(
+        #     EaseeEntityMap.Status,
+        # ) TODO(Dirk): Re-enable once we can test with a real charger
 
     def car_connected(self) -> bool:
         """See abstract Charger class for correct implementation of this method."""
@@ -158,6 +159,11 @@ class EaseeCharger(HaDevice, Charger):
             EaseeStatusMap.Charging,
             EaseeStatusMap.ReadyToCharge,
         ]
+
+    def is_charging(self) -> bool:
+        """See abstract Charger class for correct implementation of this method."""
+        status = self._get_status()
+        return status == EaseeStatusMap.Charging
 
     async def async_unload(self) -> None:
         """Unload the Easee charger."""

--- a/custom_components/evse_load_balancer/chargers/keba_charger.py
+++ b/custom_components/evse_load_balancer/chargers/keba_charger.py
@@ -142,6 +142,11 @@ class KebaCharger(HaDevice, Charger):
             KebaChargingStateMap.Charging,
         ]
 
+    def is_charging(self) -> bool:
+        """See abstract Charger class for correct implementation of this method."""
+        status = self._get_status()
+        return status == KebaChargingStateMap.Charging
+
     async def async_unload(self) -> None:
         """Unload the charger."""
 

--- a/custom_components/evse_load_balancer/chargers/lektrico_charger.py
+++ b/custom_components/evse_load_balancer/chargers/lektrico_charger.py
@@ -162,5 +162,10 @@ class LektricoCharger(HaDevice, Charger):
             LektricoStatusMap.Charging,
         ]
 
+    def is_charging(self) -> bool:
+        """See abstract Charger class for correct implementation of this method."""
+        status = self._get_status()
+        return status == LektricoStatusMap.Charging
+
     async def async_unload(self) -> None:
         """Unload the Lektri.co charger."""

--- a/custom_components/evse_load_balancer/chargers/zaptec_charger.py
+++ b/custom_components/evse_load_balancer/chargers/zaptec_charger.py
@@ -141,7 +141,6 @@ class ZaptecCharger(HaDevice, Charger):
 
     def car_connected(self) -> bool:
         """Check if a car is connected to the charger."""
-        # Fall back to status-based detection
         status = self._get_status()
         return status in (
             ZaptecStatusMap.ConnectedRequesting,
@@ -151,13 +150,16 @@ class ZaptecCharger(HaDevice, Charger):
 
     def can_charge(self) -> bool:
         """Check if the charger is in a state where it can charge."""
-        # First check if car is connected
-        if not self.car_connected():
-            return False
-
-        # Then check status to see if it's in a state where charging is possible
         status = self._get_status()
-        return status in (ZaptecStatusMap.ConnectedCharging,)
+        return status in (
+            ZaptecStatusMap.ConnectedCharging,
+            ZaptecStatusMap.ConnectedRequesting,
+        )
+
+    def is_charging(self) -> bool:
+        """Check if the charger is charging."""
+        status = self._get_status()
+        return status == ZaptecStatusMap.ConnectedCharging
 
     async def async_unload(self) -> None:
         """Unload the charger."""

--- a/custom_components/evse_load_balancer/chargers/zaptec_charger.py
+++ b/custom_components/evse_load_balancer/chargers/zaptec_charger.py
@@ -141,7 +141,6 @@ class ZaptecCharger(HaDevice, Charger):
 
     def car_connected(self) -> bool:
         """Check if a car is connected to the charger."""
-        # Fall back to status-based detection
         status = self._get_status()
         return status in (
             ZaptecStatusMap.ConnectedRequesting,
@@ -151,11 +150,11 @@ class ZaptecCharger(HaDevice, Charger):
 
     def can_charge(self) -> bool:
         """Check if the charger is in a state where it can charge."""
-        if not self.car_connected():
-            return False
-
         status = self._get_status()
-        return status in (ZaptecStatusMap.ConnectedCharging,)
+        return status in (
+            ZaptecStatusMap.ConnectedCharging,
+            ZaptecStatusMap.ConnectedRequesting,
+        )
 
     def is_charging(self) -> bool:
         """Check if the charger is charging."""

--- a/custom_components/evse_load_balancer/chargers/zaptec_charger.py
+++ b/custom_components/evse_load_balancer/chargers/zaptec_charger.py
@@ -141,6 +141,7 @@ class ZaptecCharger(HaDevice, Charger):
 
     def car_connected(self) -> bool:
         """Check if a car is connected to the charger."""
+        # Fall back to status-based detection
         status = self._get_status()
         return status in (
             ZaptecStatusMap.ConnectedRequesting,
@@ -150,11 +151,11 @@ class ZaptecCharger(HaDevice, Charger):
 
     def can_charge(self) -> bool:
         """Check if the charger is in a state where it can charge."""
+        if not self.car_connected():
+            return False
+
         status = self._get_status()
-        return status in (
-            ZaptecStatusMap.ConnectedCharging,
-            ZaptecStatusMap.ConnectedRequesting,
-        )
+        return status in (ZaptecStatusMap.ConnectedCharging,)
 
     def is_charging(self) -> bool:
         """Check if the charger is charging."""

--- a/custom_components/evse_load_balancer/coordinator.py
+++ b/custom_components/evse_load_balancer/coordinator.py
@@ -37,7 +37,7 @@ EXECUTION_CYCLE_DELAY: int = 1
 # Number of seconds between each charger update. This setting
 # makes sure that the charger is not updated too frequently and
 # allows a change of the charger's limit to actually take affect
-MIN_CHARGER_UPDATE_DELAY: int = 30
+MIN_CHARGER_UPDATE_DELAY: int = 20
 
 
 class EVSELoadBalancerCoordinator:

--- a/custom_components/evse_load_balancer/coordinator.py
+++ b/custom_components/evse_load_balancer/coordinator.py
@@ -223,9 +223,6 @@ class EVSELoadBalancerCoordinator:
         if current_limit is None:
             _LOGGER.warning("Current charger limit unknown. Cannot adjust limit.")
             return
-        if allocation_result is None:
-            _LOGGER.warning("No allocation result for charger. Cannot adjust limit.")
-            return
 
         if allocation_result and self._may_update_charger_settings(
             new_settings=allocation_result,
@@ -258,10 +255,10 @@ class EVSELoadBalancerCoordinator:
         timestamp: int,
     ) -> bool:
         """Check if the charger settings haven't been updated too recently."""
-        if self._last_charger_target_update_time is None:
+        if self._last_charger_update_time is None:
             return True
 
-        last_update_time = self._last_charger_target_update_time
+        last_update_time = self._last_charger_update_time
 
         of_charger_delay_minutes = of.EvseLoadBalancerOptionsFlow.get_option_value(
             self.config_entry, of.OPTION_CHARGE_LIMIT_HYSTERESIS
@@ -309,7 +306,7 @@ class EVSELoadBalancerCoordinator:
         self, new_limits: dict[Phase, int], timestamp: int
     ) -> None:
         _LOGGER.debug("New charger settings: %s", new_limits)
-        self._last_charger_target_update_time = timestamp
+        self._last_charger_update_time = timestamp
         self._emit_charger_event(EVENT_ACTION_NEW_CHARGER_LIMITS, new_limits)
         self.hass.async_create_task(self._charger.set_current_limit(new_limits))
 

--- a/custom_components/evse_load_balancer/coordinator.py
+++ b/custom_components/evse_load_balancer/coordinator.py
@@ -249,7 +249,7 @@ class EVSELoadBalancerCoordinator:
             self.config_entry, of.OPTION_CHARGE_LIMIT_HYSTERESIS
         )
 
-        # For increases, require minimum delay
+        # For any change a minimum delay is required
         if now - last_update_time <= MIN_CHARGER_UPDATE_DELAY:
             _LOGGER.debug(
                 "Charger settings was updated too recently (minimum delay). "
@@ -271,7 +271,7 @@ class EVSELoadBalancerCoordinator:
             )
             return True
 
-        # For increases, also require configured delay
+        # For increases, also require additional configured delay
         if now - last_update_time > (of_charger_delay_minutes * 60):
             return True
 

--- a/custom_components/evse_load_balancer/coordinator.py
+++ b/custom_components/evse_load_balancer/coordinator.py
@@ -249,16 +249,6 @@ class EVSELoadBalancerCoordinator:
             self.config_entry, of.OPTION_CHARGE_LIMIT_HYSTERESIS
         )
 
-        # Allow immediate decreases for safety (overcurrent protection)
-        if any(new_settings[p] < last_charger_target[p] for p in new_settings):
-            _LOGGER.debug(
-                "New charger settings are lower, apply immediately for safety. "
-                "Last settings: %s, new settings: %s",
-                last_charger_target,
-                new_settings,
-            )
-            return True
-
         # For increases, require minimum delay
         if now - last_update_time <= MIN_CHARGER_UPDATE_DELAY:
             _LOGGER.debug(
@@ -270,6 +260,16 @@ class EVSELoadBalancerCoordinator:
                 MIN_CHARGER_UPDATE_DELAY,
             )
             return False
+
+        # Allow immediate decreases for safety (overcurrent protection)
+        if any(new_settings[p] < last_charger_target[p] for p in new_settings):
+            _LOGGER.debug(
+                "New charger settings are lower, apply immediately for safety. "
+                "Last settings: %s, new settings: %s",
+                last_charger_target,
+                new_settings,
+            )
+            return True
 
         # For increases, also require configured delay
         if now - last_update_time > (of_charger_delay_minutes * 60):

--- a/custom_components/evse_load_balancer/coordinator.py
+++ b/custom_components/evse_load_balancer/coordinator.py
@@ -4,7 +4,6 @@ import logging
 from datetime import datetime, timedelta  # Ensure datetime is imported
 from functools import cached_property
 from math import floor
-from time import time
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -45,7 +44,7 @@ class EVSELoadBalancerCoordinator:
 
     # MODIFIED: Store as datetime object or None
     _last_check_timestamp: datetime | None = None
-    _last_charger_target_update: tuple[dict[Phase, int], int] | None = None
+    _last_charger_update_time: int | None = None
 
     def __init__(
         self,
@@ -219,8 +218,12 @@ class EVSELoadBalancerCoordinator:
         # iterate over the allocation results and update the charger
         # with the results. Just a bit of prep for the future...
         allocation_result = allocation_results.get(self._charger.id, None)
-        if allocation_result and self._may_update_charger_settings(allocation_result):
-            self._update_charger_settings(allocation_result)
+        if allocation_result and self._may_update_charger_settings(
+                new_settings=allocation_result,
+                timestamp=now.timestamp()):
+            self._update_charger_settings(
+                new_limits=allocation_result,
+                timestamp=now.timestamp())
             self._power_allocator.update_applied_current(
                 charger_id=self._charger.id,
                 applied_current=allocation_result,
@@ -237,26 +240,25 @@ class EVSELoadBalancerCoordinator:
         """Check if the charger is in a state where its limit should be managed."""
         return self._power_allocator.should_monitor()
 
-    def _may_update_charger_settings(self, new_settings: dict[Phase, int]) -> bool:
+    def _may_update_charger_settings(self, new_settings: dict[Phase, int], timestamp: int) -> bool:
         """Check if the charger settings haven't been updated too recently."""
         if self._last_charger_target_update is None:
             return True
 
         last_charger_target, last_update_time = self._last_charger_target_update
-        now = int(time())
 
         of_charger_delay_minutes = of.EvseLoadBalancerOptionsFlow.get_option_value(
             self.config_entry, of.OPTION_CHARGE_LIMIT_HYSTERESIS
         )
 
         # For any change a minimum delay is required
-        if now - last_update_time <= MIN_CHARGER_UPDATE_DELAY:
+        if timestamp - last_update_time <= MIN_CHARGER_UPDATE_DELAY:
             _LOGGER.debug(
                 "Charger settings was updated too recently (minimum delay). "
                 "Last update: %s, current time: %s. "
                 "Minimum delay: %s seconds",
                 last_update_time,
-                now,
+                timestamp,
                 MIN_CHARGER_UPDATE_DELAY,
             )
             return False
@@ -272,7 +274,7 @@ class EVSELoadBalancerCoordinator:
             return True
 
         # For increases, also require additional configured delay
-        if now - last_update_time > (of_charger_delay_minutes * 60):
+        if timestamp - last_update_time > (of_charger_delay_minutes * 60):
             return True
 
         _LOGGER.debug(
@@ -280,16 +282,16 @@ class EVSELoadBalancerCoordinator:
             "Last update: %s, current time: %s. "
             "Configured delay: %s minutes",
             last_update_time,
-            now,
+            timestamp,
             of_charger_delay_minutes,
         )
         return False
 
-    def _update_charger_settings(self, new_limits: dict[Phase, int]) -> None:
+    def _update_charger_settings(self, new_limits: dict[Phase, int], timestamp: int) -> None:
         _LOGGER.debug("New charger settings: %s", new_limits)
         self._last_charger_target_update = (
             new_limits,
-            int(time()),
+            timestamp,
         )
         self._emit_charger_event(EVENT_ACTION_NEW_CHARGER_LIMITS, new_limits)
         self.hass.async_create_task(self._charger.set_current_limit(new_limits))

--- a/tests/balancers/test_optimised_load_balancer.py
+++ b/tests/balancers/test_optimised_load_balancer.py
@@ -7,7 +7,6 @@ def test_default_init():
     for controller in lb._phase_monitors:
         assert isinstance(lb._phase_monitors[controller], PhaseMonitor)
         # Check that the default values are set correctly.
-        assert lb._phase_monitors[controller]._hold_off_period == 30
         assert lb._phase_monitors[controller]._trip_risk_threshold == 60
         assert lb._phase_monitors[controller]._risk_decay_per_second == 1.0
         assert lb._phase_monitors[controller].max_limit == 25
@@ -48,7 +47,7 @@ def test_stable_recovery_triggers_increase():
     lb = OptimisedLoadBalancer(max_limits=dict.fromkeys(Phase, 25))
     # Setup a scenario where recovery is stable and enough time has elapsed.
     available_currents = {phase: 5 for phase in Phase}
-    now = 100  # elapsed (100 seconds) > hold_off_period (30 seconds)
+    now = 100  # elapsed (100 seconds)
     new_limits = lb.compute_availability(available_currents, now)
     for phase in Phase:
         assert new_limits[phase] == 5

--- a/tests/chargers/test_amina_charger.py
+++ b/tests/chargers/test_amina_charger.py
@@ -122,6 +122,16 @@ def test_car_connected_false(amina_charger):
     assert amina_charger.car_connected() is False
 
 
+def test_is_charging_true(amina_charger):
+    amina_charger._state_cache[AminaPropertyMap.Charging] = True
+    assert amina_charger.is_charging() is True
+
+
+def test_is_charging_false(amina_charger):
+    amina_charger._state_cache[AminaPropertyMap.EvConnected] = False
+    assert amina_charger.is_charging() is False
+
+
 def test_can_charge_false_not_connected(amina_charger):
     amina_charger._state_cache[AminaPropertyMap.EvConnected] = False
     assert amina_charger.can_charge() is False

--- a/tests/chargers/test_easee_charger.py
+++ b/tests/chargers/test_easee_charger.py
@@ -93,8 +93,6 @@ def test_get_current_limit_success(easee_charger):
 
     # Call the method
     result = easee_charger.get_current_limit()
-
-    # Verify results
     assert result == {Phase.L1: 16, Phase.L2: 16, Phase.L3: 16}
     easee_charger._get_entity_state_by_translation_key.assert_called_once_with(
         EaseeEntityMap.DynamicChargerLimit
@@ -108,8 +106,6 @@ def test_get_current_limit_missing_entity(easee_charger):
 
     # Call the method
     result = easee_charger.get_current_limit()
-
-    # Verify results
     assert result is None
     easee_charger._get_entity_state_by_translation_key.assert_called_once_with(
         EaseeEntityMap.DynamicChargerLimit
@@ -123,8 +119,6 @@ def test_get_max_current_limit_success(easee_charger):
 
     # Call the method
     result = easee_charger.get_max_current_limit()
-
-    # Verify results
     assert result == {Phase.L1: 32, Phase.L2: 32, Phase.L3: 32}
     easee_charger._get_entity_state_by_translation_key.assert_called_once_with(
         EaseeEntityMap.MaxChargerLimit
@@ -138,8 +132,6 @@ def test_get_max_current_limit_missing_entity(easee_charger):
 
     # Call the method
     result = easee_charger.get_max_current_limit()
-
-    # Verify results
     assert result is None
     easee_charger._get_entity_state_by_translation_key.assert_called_once_with(
         EaseeEntityMap.MaxChargerLimit
@@ -154,13 +146,10 @@ def test_car_connected_true(easee_charger):
         EaseeStatusMap.Completed,
         EaseeStatusMap.ReadyToCharge,
     ]:
-        # Mock the status
         easee_charger._get_entity_state_by_translation_key.return_value = status
 
-        # Call the method
         result = easee_charger.car_connected()
 
-        # Verify results
         assert result is True
 
 
@@ -173,13 +162,10 @@ def test_car_connected_false(easee_charger):
         EaseeStatusMap.DeAuthorization,
         None,  # Test with no status
     ]:
-        # Mock the status
         easee_charger._get_entity_state_by_translation_key.return_value = status
 
-        # Call the method
         result = easee_charger.car_connected()
 
-        # Verify results
         assert result is False
 
 
@@ -190,13 +176,10 @@ def test_can_charge_true(easee_charger):
         EaseeStatusMap.Charging,
         EaseeStatusMap.ReadyToCharge,
     ]:
-        # Mock the status
         easee_charger._get_entity_state_by_translation_key.return_value = status
 
-        # Call the method
         result = easee_charger.can_charge()
 
-        # Verify results
         assert result is True
 
 
@@ -210,13 +193,37 @@ def test_can_charge_false(easee_charger):
         EaseeStatusMap.DeAuthorization,
         None,  # Test with no status
     ]:
-        # Mock the status
         easee_charger._get_entity_state_by_translation_key.return_value = status
 
-        # Call the method
         result = easee_charger.can_charge()
 
-        # Verify results
+        assert result is False
+
+
+def test_is_charging_true(easee_charger):
+    """Test is_charging returns True for valid statuses."""
+    easee_charger._get_entity_state_by_translation_key.return_value = EaseeStatusMap.Charging
+    result = easee_charger.is_charging()
+
+    assert result is True
+
+
+def test_is_charging_false(easee_charger):
+    """Test is_charging returns False for invalid statuses."""
+    for status in [
+        EaseeStatusMap.Disconnected,
+        EaseeStatusMap.Error,
+        EaseeStatusMap.Completed,
+        EaseeStatusMap.AwaitingAuthorization,
+        EaseeStatusMap.DeAuthorization,
+        EaseeStatusMap.AwaitingStart,
+        EaseeStatusMap.ReadyToCharge,
+        None,
+    ]:
+        easee_charger._get_entity_state_by_translation_key.return_value = status
+
+        result = easee_charger.is_charging()
+
         assert result is False
 
 

--- a/tests/chargers/test_easee_charger.py
+++ b/tests/chargers/test_easee_charger.py
@@ -166,7 +166,7 @@ def test_car_connected_false(easee_charger):
 
         result = easee_charger.car_connected()
 
-        assert result is False
+        assert result is False, f"Failed for status: {status}"
 
 
 def test_can_charge_true(easee_charger):

--- a/tests/chargers/test_lektrico_charger.py
+++ b/tests/chargers/test_lektrico_charger.py
@@ -263,11 +263,8 @@ def test_car_connected_true(lektrico_charger):
     ]:
         # Mock the status
         lektrico_charger._get_entity_state_by_key.return_value = status
-
-        # Call the method
         result = lektrico_charger.car_connected()
 
-        # Verify results
         assert result is True
 
 
@@ -283,11 +280,8 @@ def test_car_connected_false(lektrico_charger):
     ]:
         # Mock the status
         lektrico_charger._get_entity_state_by_key.return_value = status
-
-        # Call the method
         result = lektrico_charger.car_connected()
 
-        # Verify results
         assert result is False
 
 
@@ -299,11 +293,8 @@ def test_can_charge_true(lektrico_charger):
     ]:
         # Mock the status
         lektrico_charger._get_entity_state_by_key.return_value = status
-
-        # Call the method
         result = lektrico_charger.can_charge()
 
-        # Verify results
         assert result is True
 
 
@@ -321,11 +312,34 @@ def test_can_charge_false(lektrico_charger):
     ]:
         # Mock the status
         lektrico_charger._get_entity_state_by_key.return_value = status
-
-        # Call the method
         result = lektrico_charger.can_charge()
 
-        # Verify results
+        assert result is False
+
+
+def test_is_charging_true(lektrico_charger):
+    """Test is_charging returns True for valid statuses."""
+    lektrico_charger._get_entity_state_by_key.return_value = LektricoStatusMap.Charging
+    result = lektrico_charger.is_charging()
+
+    assert result is True
+
+
+def test_is_charging_false(lektrico_charger):
+    """Test is_charging returns False for invalid statuses."""
+    for status in [
+        LektricoStatusMap.Available,
+        LektricoStatusMap.Error,
+        LektricoStatusMap.Locked,
+        LektricoStatusMap.Authentication,
+        LektricoStatusMap.Paused,
+        LektricoStatusMap.PausedByScheduler,
+        LektricoStatusMap.Updating,
+        None,
+    ]:
+        lektrico_charger._get_entity_state_by_key.return_value = status
+        result = lektrico_charger.is_charging()
+
         assert result is False
 
 

--- a/tests/chargers/test_zaptec_charger.py
+++ b/tests/chargers/test_zaptec_charger.py
@@ -226,6 +226,7 @@ def test_can_charge_true(zaptec_charger):
     """Test can_charge returns True for valid statuses when car is connected."""
     for status in [
         ZaptecStatusMap.ConnectedCharging,
+        ZaptecStatusMap.ConnectedRequesting,
     ]:
         # Reset the mock
         zaptec_charger._get_entity_state_by_translation_key.reset_mock()
@@ -270,6 +271,28 @@ def test_can_charge_false(zaptec_charger):
     result = zaptec_charger.can_charge()
 
     # Verify results
+    assert result is False
+
+
+def test_is_charging_true(zaptec_charger):
+    """Test is_charging returns True for valid statuses when car is connected."""
+    zaptec_charger._get_entity_state_by_translation_key.reset_mock()
+
+    zaptec_charger._get_entity_state_by_translation_key.return_value = ZaptecStatusMap.ConnectedCharging
+
+    result = zaptec_charger.is_charging()
+
+    assert result is True
+
+
+def test_is_charging_false(zaptec_charger):
+    """Test is_charging returns False for invalid statuses or when car is not connected."""
+    zaptec_charger._get_entity_state_by_translation_key.reset_mock()
+
+    zaptec_charger._get_entity_state_by_translation_key.return_value = ZaptecStatusMap.ConnectedRequesting
+
+    result = zaptec_charger.is_charging()
+
     assert result is False
 
 

--- a/tests/helpers/mock_charger.py
+++ b/tests/helpers/mock_charger.py
@@ -28,6 +28,7 @@ class MockCharger(Charger):
         self._synced_phases = synced_phases
         self._is_car_connected = False
         self._can_charge_state = False
+        self._is_charging = False
 
     def is_charger_device(self, device) -> bool:
         """Check if the given device is a mock charger."""
@@ -69,6 +70,10 @@ class MockCharger(Charger):
         """Return whether the car can charge."""
         return self._can_charge_state
 
+    def is_charging(self) -> bool:
+        """Return whether the car is charging."""
+        return self._is_charging
+
     # Test helper methods
     def set_car_connected(self, connected: bool) -> None:
         """Set whether a car is connected for testing."""
@@ -77,6 +82,10 @@ class MockCharger(Charger):
     def set_can_charge(self, can_charge: bool) -> None:
         """Set whether the car can charge for testing."""
         self._can_charge_state = can_charge
+
+    def set_is_charging(self, is_charging: bool) -> None:
+        """Set whether the car is charging."""
+        self._is_charging = is_charging
 
     def set_current_limits(self, limits: Dict[Phase, int]) -> None:
         """Manually set the current limits for testing."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1013,7 +1013,7 @@ def test_overcurrent_does_not_bypass_fixed_timing_restrictions(coordinator_singl
     # Setup: Recent charger update (within all timing windows)
     coordinator_single_phase._last_charger_target_update = (
         {Phase.L1: 15},
-        int(datetime.now().timestamp()) - 15  # Just 25 seconds ago
+        int(datetime.now().timestamp()) - 15
     )
 
     # Setup: Overcurrent situation

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -336,9 +336,8 @@ def test_no_update_when_charger_shouldnt_be_checked(coordinator):
 def test_no_update_too_frequent(coordinator):
     """Test that no update happens when last update was too recent."""
     # Set recent update time
-    coordinator._last_charger_target_update = (
-        {Phase.L1: 10, Phase.L2: 10, Phase.L3: 10},
-        int(datetime.now().timestamp()) - 10,  # 10 seconds ago (less than MIN_CHARGER_UPDATE_DELAY)
+    coordinator._last_charger_update_time = (
+        int(datetime.now().timestamp()) - 10  # 10 seconds ago (less than MIN_CHARGER_UPDATE_DELAY)
     )
 
     # Execute update cycle

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -284,8 +284,8 @@ def test_no_update_when_available_current_unknown(coordinator):
     coordinator._charger.set_current_limit.assert_not_called()
 
 
-def test_only_update_when_currents_have_changed(coordinator):
-    """Tests that no update happens on the allocator when the currents haven't changed."""
+def test_allocator_always_called_to_check_current_power(coordinator):
+    """Tests that allocator is always called to check current available power."""
     # Execute an update cycle
     coordinator._execute_update_cycle(datetime.now())
 
@@ -299,17 +299,18 @@ def test_only_update_when_currents_have_changed(coordinator):
         Phase.L3: 5
     }
 
-    # Call second time, with same values, verify no update
+    # Call second time, with same values - should still call allocator
+    # (We always check current power, no optimization based on previous values)
     coordinator._execute_update_cycle(datetime.now())
     assert coordinator._balancer_algo.compute_availability.call_count == 2
-    assert coordinator._power_allocator.update_allocation.call_count == 1
+    assert coordinator._power_allocator.update_allocation.call_count == 2
 
     # Mock different values
     coordinator._balancer_algo.compute_availability.return_value = dict.fromkeys(Phase, 2)
 
     coordinator._execute_update_cycle(datetime.now())
     assert coordinator._balancer_algo.compute_availability.call_count == 3
-    assert coordinator._power_allocator.update_allocation.call_count == 2
+    assert coordinator._power_allocator.update_allocation.call_count == 3
     allocation_args = coordinator._power_allocator.update_allocation.call_args[1]
     assert allocation_args["available_currents"] == {
         Phase.L1: 2,
@@ -461,8 +462,8 @@ def test_no_update_when_available_current_unknown_single_phase(coordinator_singl
     coordinator_single_phase._charger.set_current_limit.assert_not_called()
 
 
-def test_only_update_when_currents_have_changed_single_phase(coordinator_single_phase):
-    """Tests that no update happens on the allocator when the currents haven't changed in single phase setup."""
+def test_allocator_always_called_to_check_current_power_single_phase(coordinator_single_phase):
+    """Tests that allocator is always called to check current available power in single phase setup."""
     # Execute an update cycle
     coordinator_single_phase._execute_update_cycle(datetime.now())
 
@@ -474,17 +475,18 @@ def test_only_update_when_currents_have_changed_single_phase(coordinator_single_
         Phase.L1: -2,
     }
 
-    # Call second time, with same values, verify no update
+    # Call second time, with same values - should still call allocator
+    # (We always check current power, no optimization based on previous values)
     coordinator_single_phase._execute_update_cycle(datetime.now())
     assert coordinator_single_phase._balancer_algo.compute_availability.call_count == 2
-    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 2
 
     # Mock different values
     coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 2}
 
     coordinator_single_phase._execute_update_cycle(datetime.now())
     assert coordinator_single_phase._balancer_algo.compute_availability.call_count == 3
-    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 2
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 3
     allocation_args = coordinator_single_phase._power_allocator.update_allocation.call_args[1]
     assert allocation_args["available_currents"] == {
         Phase.L1: 2,
@@ -707,24 +709,47 @@ def test_single_phase_balancer_initialization(coordinator_single_phase):
     assert available_phases[0] == Phase.L1
 
 
-def test_single_phase_current_stability_check(coordinator_single_phase):
-    """Test that single phase current stability checks work correctly."""
-    # Set initial availability
-    coordinator_single_phase._previous_current_availability = {Phase.L1: 5}
+def test_single_phase_timing_restrictions_work_correctly(coordinator_single_phase):
+    """Test that single phase timing restrictions work correctly (simplified - no availability tracking)."""
+    # Since we removed availability tracking, this test now focuses on timing restrictions only
 
-    # Test with same current - should not act
-    assert not coordinator_single_phase._should_act_upon_availability({Phase.L1: 5})
+    # Set recent update time to test timing restrictions
+    coordinator_single_phase._last_charger_target_update = (
+        {Phase.L1: 15},
+        int(datetime.now().timestamp()) - 10,  # 10 seconds ago
+    )
 
-    # Test with different current - should act
-    assert coordinator_single_phase._should_act_upon_availability({Phase.L1: 3})
+    # Setup allocation that would suggest an increase (timing should block this)
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 3}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        TEST_CHARGER_ID: {Phase.L1: 16}  # Increase
+    }
 
-    # Test with first run (no previous availability) - should act
-    coordinator_single_phase._previous_current_availability = None
-    assert coordinator_single_phase._should_act_upon_availability({Phase.L1: 5})
+    # Execute update cycle
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Balancer and allocator should still be called to check current power
+    assert coordinator_single_phase._balancer_algo.compute_availability.called
+    assert coordinator_single_phase._power_allocator.update_allocation.called
+
+    # But charger should not be updated due to timing delay for increases
+    coordinator_single_phase._charger.set_current_limit.assert_not_called()
+
+    # Test that decreases (safety) bypass timing restrictions
+    coordinator_single_phase._charger.set_current_limit.reset_mock()
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: -2}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        TEST_CHARGER_ID: {Phase.L1: 10}  # Decrease for safety
+    }
+
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Charger should be updated immediately for safety (decrease)
+    coordinator_single_phase._charger.set_current_limit.assert_called_once_with({Phase.L1: 10})
 
 
-def test_single_phase_multiple_update_cycles(coordinator_single_phase):
-    """Test multiple update cycles work correctly for single phase."""
+def test_single_phase_allocator_always_called(coordinator_single_phase):
+    """Test that allocator is always called to check current power for single phase."""
     # First cycle - overcurrent
     coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: -2}
     coordinator_single_phase._power_allocator.update_allocation.return_value = {
@@ -737,12 +762,13 @@ def test_single_phase_multiple_update_cycles(coordinator_single_phase):
     assert coordinator_single_phase._balancer_algo.compute_availability.call_count == 1
     assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
 
-    # Second cycle - same values, should not update allocator
+    # Second cycle - same values, should still call allocator
+    # (Always check current power, no optimization)
     coordinator_single_phase._execute_update_cycle(datetime.now())
 
-    # Balancer should be called again but allocator should not (no change)
+    # Both should be called again to check current power
     assert coordinator_single_phase._balancer_algo.compute_availability.call_count == 2
-    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 2
 
     # Third cycle - different values
     coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 3}
@@ -754,25 +780,31 @@ def test_single_phase_multiple_update_cycles(coordinator_single_phase):
 
     # Both should be called again
     assert coordinator_single_phase._balancer_algo.compute_availability.call_count == 3
-    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 2
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 3
 
 
-def test_single_phase_charger_update_delay(coordinator_single_phase):
-    """Test that charger update delay works correctly for single phase."""
+def test_single_phase_charger_timing_restrictions(coordinator_single_phase):
+    """Test that charger timing restrictions work correctly for single phase."""
     # Set recent update time
     coordinator_single_phase._last_charger_target_update = (
         {Phase.L1: 15},
         int(datetime.now().timestamp()) - 10,  # 10 seconds ago
     )
 
+    # Setup an increase scenario (should be blocked by timing)
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 2}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        TEST_CHARGER_ID: {Phase.L1: 16}  # Increase
+    }
+
     # Execute update cycle
     coordinator_single_phase._execute_update_cycle(datetime.now())
 
-    # Balancer and allocator should still be called
+    # Balancer and allocator should still be called to check current power
     assert coordinator_single_phase._balancer_algo.compute_availability.called
     assert coordinator_single_phase._power_allocator.update_allocation.called
 
-    # But charger should not be updated due to delay
+    # But charger should not be updated due to timing delay for increases
     coordinator_single_phase._charger.set_current_limit.assert_not_called()
 
 
@@ -793,3 +825,218 @@ def test_single_phase_charger_update_after_delay(coordinator_single_phase):
 
     # Charger should be updated
     coordinator_single_phase._charger.set_current_limit.assert_called_once()
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Charger should be updated
+    coordinator_single_phase._charger.set_current_limit.assert_called_once()
+
+
+def test_charger_update_timing_and_frequency_control(coordinator_single_phase):
+    """Test end-to-end scenario for charger update timing and frequency control."""
+
+    # Scenario setup: We'll simulate multiple 5-second cycles with positive available current
+    # and verify that charger updates follow the timing rules
+
+    base_time = int(datetime.now().timestamp())
+
+    # Setup: Start with positive available current that should trigger an increase
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 5}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        coordinator_single_phase._charger.id: {Phase.L1: 12}  # Suggested increase
+    }
+
+    # === CYCLE 1: No previous update, should update immediately ===
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Power allocator was called and charger was updated
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 1
+    coordinator_single_phase._charger.set_current_limit.assert_called_with({Phase.L1: 12})
+
+    # Reset mocks for next cycles
+    coordinator_single_phase._power_allocator.update_allocation.reset_mock()
+    coordinator_single_phase._charger.set_current_limit.reset_mock()
+
+    # Simulate that charger was just updated
+    coordinator_single_phase._last_charger_target_update = (
+        {Phase.L1: 12},
+        base_time  # Just updated
+    )
+
+    # === CYCLE 2: 5 seconds later, still positive current ===
+    # Should NOT update due to 30-second minimum delay
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Power allocator called (availability checked) but charger NOT updated
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 0
+
+    coordinator_single_phase._power_allocator.update_allocation.reset_mock()
+
+    # === CYCLE 3: 10 seconds later, still positive current ===
+    # Should still NOT update due to 30-second minimum delay
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Power allocator called but charger still NOT updated
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 0
+
+    coordinator_single_phase._power_allocator.update_allocation.reset_mock()
+
+    # === CYCLE 4: 35 seconds later, positive current, should allow update for increases only after 15 minutes ===
+    coordinator_single_phase._last_charger_target_update = (
+        {Phase.L1: 12},
+        base_time - 35  # 35 seconds ago (past 30s minimum)
+    )
+
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Power allocator called but charger still NOT updated (needs 15 minutes for increases)
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 0
+
+    coordinator_single_phase._power_allocator.update_allocation.reset_mock()
+
+    # === CYCLE 5: Test immediate update for DECREASES (overcurrent protection) ===
+    # Change to negative current (overcurrent)
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: -3}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        coordinator_single_phase._charger.id: {Phase.L1: 8}  # Suggested decrease
+    }
+
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Should update immediately for safety (overcurrent protection)
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 1
+    coordinator_single_phase._charger.set_current_limit.assert_called_with({Phase.L1: 8})
+
+    coordinator_single_phase._power_allocator.update_allocation.reset_mock()
+    coordinator_single_phase._charger.set_current_limit.reset_mock()
+
+    # === CYCLE 6: After 15+ minutes, positive current should allow increase ===
+    coordinator_single_phase._last_charger_target_update = (
+        {Phase.L1: 8},
+        base_time - (15 * 60 + 60)  # Over 15 minutes ago
+    )
+
+    # Back to positive current
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 4}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        coordinator_single_phase._charger.id: {Phase.L1: 11}  # Suggested increase
+    }
+
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Should now allow increase after 15-minute delay
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 1
+    coordinator_single_phase._charger.set_current_limit.assert_called_with({Phase.L1: 11})
+
+
+def test_allocator_called_every_cycle_regardless_of_availability_changes(coordinator_single_phase):
+    """Test that power allocator is called every cycle to check current available power."""
+
+    # Setup: Initial availability
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 5}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        coordinator_single_phase._charger.id: {Phase.L1: 12}
+    }
+
+    # === CYCLE 1: First run, should call allocator ===
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 1
+
+    coordinator_single_phase._power_allocator.update_allocation.reset_mock()
+    coordinator_single_phase._charger.set_current_limit.reset_mock()
+
+    # === CYCLE 2: Same availability, should STILL call allocator ===
+    # (We always check current power, no previous availability tracking)
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Both balancer and allocator called to check current power
+    assert coordinator_single_phase._balancer_algo.compute_availability.call_count == 2
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    # Charger not updated due to timing restrictions, but allocator still called
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 0
+
+    # === CYCLE 3: Different availability, should call allocator ===
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 3}
+
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Allocator called as always
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 2
+
+    coordinator_single_phase._power_allocator.update_allocation.reset_mock()
+
+    # === CYCLE 4: Back to same availability as cycle 3, should STILL call allocator ===
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Always check current power - no optimization based on previous availability
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+
+
+def test_overcurrent_bypasses_all_timing_restrictions(coordinator_single_phase):
+    """Test that overcurrent situations bypass all timing restrictions for immediate action."""
+
+    # Setup: Recent charger update (within all timing windows)
+    coordinator_single_phase._last_charger_target_update = (
+        {Phase.L1: 15},
+        int(datetime.now().timestamp()) - 5  # Just 5 seconds ago
+    )
+
+    # Setup: Overcurrent situation
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: -5}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        coordinator_single_phase._charger.id: {Phase.L1: 8}  # Emergency reduction
+    }
+
+    # Execute cycle
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Despite recent update, charger should be updated immediately for safety
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 1
+    coordinator_single_phase._charger.set_current_limit.assert_called_with({Phase.L1: 8})
+
+
+def test_timing_prevents_rapid_increases_but_allows_decreases(coordinator_single_phase):
+    """Test that timing restrictions prevent rapid increases but always allow decreases."""
+
+    base_time = int(datetime.now().timestamp())
+
+    # Setup: Recent charger update
+    coordinator_single_phase._last_charger_target_update = (
+        {Phase.L1: 10},
+        base_time - 10  # 10 seconds ago (within 30s minimum delay)
+    )
+
+    # === Test 1: Positive current (increase) should be blocked ===
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: 3}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        coordinator_single_phase._charger.id: {Phase.L1: 13}  # Increase
+    }
+
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Allocator called but charger NOT updated (blocked by timing)
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 0
+
+    coordinator_single_phase._power_allocator.update_allocation.reset_mock()
+
+    # === Test 2: Negative current (decrease) should NOT be blocked ===
+    coordinator_single_phase._balancer_algo.compute_availability.return_value = {Phase.L1: -2}
+    coordinator_single_phase._power_allocator.update_allocation.return_value = {
+        coordinator_single_phase._charger.id: {Phase.L1: 7}  # Decrease
+    }
+
+    coordinator_single_phase._execute_update_cycle(datetime.now())
+
+    # Verify: Both allocator and charger should be called (safety override)
+    assert coordinator_single_phase._power_allocator.update_allocation.call_count == 1
+    assert coordinator_single_phase._charger.set_current_limit.call_count == 1
+    coordinator_single_phase._charger.set_current_limit.assert_called_with({Phase.L1: 7})


### PR DESCRIPTION
Fixes #60 by reducing a "previous current" memory which seems to be causing race conditions. Removal of the memorisation should simplify things and hopefully remove the bug. Guards preventing double allocation are still in place by time controls, which should be enough. 

Install:
```
action: update.install
target:
  entity_id: update.evse_load_balancer_update
data:
  version: 94aefcad9d93c450ad3dd97f264bb15980997814
```