### PR TITLE
[#34] Add configurable overcurrent mode for peak-billing scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 [![easee_hass](https://img.shields.io/github/release/dirkgroenen/hass-evse-load-balancer.svg?1)](https://github.com/dirkgroenen/hass-evse-load-balancer) ![Validate with hassfest](https://github.com/dirkgroenen/hass-evse-load-balancer/workflows/Validate%20with%20Hassfest%20and%20HACS/badge.svg) ![Maintenance](https://img.shields.io/maintenance/yes/2025.svg) [![Easee_downloads](https://img.shields.io/github/downloads/dirkgroenen/hass-evse-load-balancer/total)](https://github.com/dirkgroenen/hass-evse-load-balancer) [![easee_hass_downloads](https://img.shields.io/github/downloads/dirkgroenen/hass-evse-load-balancer/latest/total)](https://github.com/dirkgroenen/hass-evse-load-balancer)
 
-
-# EVSE Load Balancer for Home Assistant 🚗⚡️ 
+# EVSE Load Balancer for Home Assistant 🚗⚡️
 
 **EVSE Load Balancer** is an integration for [Home Assistant](https://www.home-assistant.io/) that provides a **universal load balancing solution for electric vehicle (EV) chargers**. It eliminates the need for additional vendor-specific hardware (and endless P1-port device clutter) by leveraging existing energy meters and sensors in your Home Assistant setup.
 
-- No more need of custom automation scripts trying to protect your main fuse 
+- No more need of custom automation scripts trying to protect your main fuse
 - No more additional hardware on your P1 port.
 
 ---
@@ -34,32 +33,32 @@
 
 ## Supported Devices
 
-> **⚠️ Important notice:** I can personally only test the DSMR and Easee integration. Support 
+> **⚠️ Important notice:** I can personally only test the DSMR and Easee integration. Support
 > from the community is well appreciated to test other chargers and make contributions where required.
 > Chargers and meters are implemented with best-effort, but often purely based on API documentation and available code.
 
 ### Energy Meters
 
-| Integration | Documentation | Minimum Version |
-|-------------|---------------|----------------|
-| DSMR-compatible meters | [DSMR Smart Meter](https://www.home-assistant.io/integrations/dsmr/) | ? |
-| HomeWizard meters | [HomeWizard](https://www.home-assistant.io/integrations/homewizard/) | ? |
-| AmsLeser.no | [MQTT](https://wiki.amsleser.no/en/HomeAutomation/Home-Assistant) | ? |
-| Custom configurations | Existing Home Assistant sensors | n.a. |
+| Integration            | Documentation                                                        | Minimum Version |
+| ---------------------- | -------------------------------------------------------------------- | --------------- |
+| DSMR-compatible meters | [DSMR Smart Meter](https://www.home-assistant.io/integrations/dsmr/) | ?               |
+| HomeWizard meters      | [HomeWizard](https://www.home-assistant.io/integrations/homewizard/) | ?               |
+| AmsLeser.no            | [MQTT](https://wiki.amsleser.no/en/HomeAutomation/Home-Assistant)    | ?               |
+| Custom configurations  | Existing Home Assistant sensors                                      | n.a.            |
 
-*Supports 1-3 Phase configurations*
+_Supports 1-3 Phase configurations_
 
 ### EV Chargers
 
-| Integration | Documentation | Minimum Version |
-|-------------|---------------|----------------|
-| Easee Chargers | [nordicopen/easee_hass](https://github.com/nordicopen/easee_hass) | v0.9.62 |
-| Zaptec Chargers | [custom-components/zaptec](https://github.com/custom-components/zaptec) | v0.8.0 |
-| Amina S Chargers | [Zigbee2MQTT/amina_S](https://www.zigbee2mqtt.io/devices/amina_S.html) | ? |
-| Lektrico Chargers | [lektrico](https://www.home-assistant.io/integrations/lektrico/) | HA 2024.10+ |
-| Keba Charging Station (BMW Wallbox) | [keba](https://www.home-assistant.io/integrations/keba/) | ? |
+| Integration                         | Documentation                                                           | Minimum Version |
+| ----------------------------------- | ----------------------------------------------------------------------- | --------------- |
+| Easee Chargers                      | [nordicopen/easee_hass](https://github.com/nordicopen/easee_hass)       | v0.9.62         |
+| Zaptec Chargers                     | [custom-components/zaptec](https://github.com/custom-components/zaptec) | v0.8.0          |
+| Amina S Chargers                    | [Zigbee2MQTT/amina_S](https://www.zigbee2mqtt.io/devices/amina_S.html)  | ?               |
+| Lektrico Chargers                   | [lektrico](https://www.home-assistant.io/integrations/lektrico/)        | HA 2024.10+     |
+| Keba Charging Station (BMW Wallbox) | [keba](https://www.home-assistant.io/integrations/keba/)                | ?               |
 
-*Additional chargers to be added...*
+_Additional chargers to be added..._
 
 ## How It Works
 
@@ -70,19 +69,30 @@ Key parts of the process include:
 - **Real-Time Monitoring:**  
   The balancer reads your meter's current consumption on each phase and calculates the remaining “available current”, which is basically the difference between your fuse’s capacity and your current load.
 
-- **Risk-Based Adjustments:**  
-  When the available current drops below zero (indicating potential overload), the algorithm quickly increases an accumulated "risk" factor. Once this risk exceeds a preset threshold, the charger’s current limit is immediately reduced to protect your circuit. 
-  
-  These "risk presets" are derived from the thermal behavior of B- and C-character circuit breakers. The algorithm tolerates brief overcurrent spikes, accumulating risk over time; if these spikes are too frequent or severe, the risk level exceeds a set threshold and the charger’s limit is immediately reduced to protect your fuse. Conversely, when surplus power is detected, the system only restores charging power after confirming that recovery conditions are stable over a configurable time period (a minimum of 15 minutes, extendable during periods of unstable usage).
-  
+- **Risk-Based Adjustments:**
+  The load balancer offers two modes for handling overcurrent situations, configurable based on your specific requirements:
+
+  **Optimised Mode (Default):**
+  When the available current drops below zero (indicating potential overload), the algorithm increases an accumulated "risk" factor. Once this risk exceeds a preset threshold, the charger's current limit is immediately reduced to protect your circuit. These "risk presets" are derived from the thermal behavior of B- and C-character circuit breakers. The algorithm tolerates brief overcurrent spikes, accumulating risk over time; if these spikes are too frequent or severe, the risk level exceeds a set threshold and the charger's limit is immediately reduced to protect your fuse.
+
+  **Conservative Mode:**
+  When "Allow temporary overcurrent" is disabled, the algorithm immediately reduces the charger's current limit as soon as overcurrent is detected, without any tolerance for spikes. This mode is recommended for:
+
+  - Electricity contracts with peak-based billing
+  - Strict grid connection agreements that prohibit any overcurrent
+  - Installations with sensitive circuit breakers
+
+  Regardless of mode, when surplus power is detected, the system only restores charging power after confirming that recovery conditions are stable over a configurable time period (a minimum of 15 minutes, extendable during periods of unstable usage).
+
 - **Per-Phase Balancing:**  
   All calculations are performed separately for each electrical phase, ensuring that the load is balanced and your circuit remains safe under varying conditions. The ability to make use of this depends on your charger's capabilities though.
 
-This adaptive approach allows the EVSE Load Balancer to optimize charging power while preventing overloads, making the most of your available energy, putting the least amount of stress on your charger, car and circuit breaker. 
+This adaptive approach allows the EVSE Load Balancer to optimize charging power while preventing overloads, making the most of your available energy, putting the least amount of stress on your charger, car and circuit breaker.
 
 ## Installation
 
 ### HACS installation
+
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=dirkgroenen&repository=hass-evse-load-balancer)
 
 1. Search for "EVSE Load Balancer" in **HACS > Integrations**
@@ -90,6 +100,7 @@ This adaptive approach allows the EVSE Load Balancer to optimize charging power 
 3. Add the integration via **Settings > Devices & Services > Add Integration** and search for "EVSE Load Balancer."
 
 ### Manual
+
 1. Copy the `custom_components/evse_load_balancer` folder to your Home Assistant `custom_components` directory.
 2. Restart Home Assistant.
 3. Add the integration via **Settings > Devices & Services > Add Integration** and search for "EVSE Load Balancer."
@@ -97,12 +108,15 @@ This adaptive approach allows the EVSE Load Balancer to optimize charging power 
 ## Configuration
 
 During setup, you will be prompted to:
+
 - Select your EV charger.
 - Select your energy meter or provide custom sensors
 - Specify the fuse size and number of phases in your home.
 
 ### Advanced Configuration
+
 For homes without a compatible energy meter, you can manually configure sensors for each phase, including:
+
 - Power consumption (in **kW**)
 - Power production (in **kW**)
 - Voltage
@@ -113,15 +127,16 @@ For homes without a compatible energy meter, you can manually configure sensors 
 
 The integration emits events to Home Assistant's event log whenever the charger current limit is adjusted. These events can be used to create automations or monitor the system's behavior.
 
-
 ## Contributing
 
 Contributions are welcome! If you encounter any issues or have ideas for improvements, feel free to open an issue or submit a pull request on the [GitHub repository](https://github.com/dirkgroenen/hass-evse-load-balancer).
 
-### Adding Charger or Meter support 
+### Adding Charger or Meter support
+
 You can support EVSE Load Balancer by adding and testing additional chargers or meters. A brief overview of the steps required to follow:
 
 1. **Create a New Charger Class**:
+
    - Create a new file in the `chargers` directory (e.g., `my_charger.py`).
    - Implement the `Charger` abstract base class from [`charger.py`](custom_components/evse_load_balancer/chargers/charger.py).
 
@@ -135,6 +150,7 @@ You can support EVSE Load Balancer by adding and testing additional chargers or 
 #### Adding a New Meter
 
 1. **Create a New Meter Class**:
+
    - Create a new file in the `meters` directory (e.g., `my_meter.py`).
    - Implement the `Meter` abstract base class from [`meter.py`](custom_components/evse_load_balancer/meters/meter.py).
 
@@ -144,5 +160,3 @@ You can support EVSE Load Balancer by adding and testing additional chargers or 
 3. **Register the Meter**:
    - Update the `meter_factory` function in [`meters/__init__.py`](custom_components/evse_load_balancer/meters/__init__.py) to include your new meter class.
    - Add logic to detect the new meter based on its manufacturer or other identifiers.
-
-

--- a/custom_components/evse_load_balancer/const.py
+++ b/custom_components/evse_load_balancer/const.py
@@ -45,3 +45,10 @@ class Phase(Enum):
     L1 = "l1"
     L2 = "l2"
     L3 = "l3"
+
+
+class OvercurrentMode(Enum):
+    """Enum for overcurrent handling modes."""
+
+    CONSERVATIVE = "conservative"
+    OPTIMISED = "optimised"

--- a/custom_components/evse_load_balancer/coordinator.py
+++ b/custom_components/evse_load_balancer/coordinator.py
@@ -24,6 +24,7 @@ from .const import (
     EVENT_ATTR_ACTION,
     EVENT_ATTR_NEW_LIMITS,
     EVSE_LOAD_BALANCER_COORDINATOR_EVENT,
+    OvercurrentMode,
 )
 from .meters.meter import Meter, Phase
 from .power_allocator import PowerAllocator
@@ -78,8 +79,18 @@ class EVSELoadBalancerCoordinator:
         )
 
         max_limits = dict.fromkeys(self._available_phases, self.fuse_size)
+        allow_temporary_overcurrent = of.EvseLoadBalancerOptionsFlow.get_option_value(
+            self.config_entry,
+            of.OPTION_ALLOW_TEMPORARY_OVERCURRENT,
+        )
+        overcurrent_mode = (
+            OvercurrentMode.OPTIMISED
+            if allow_temporary_overcurrent
+            else OvercurrentMode.CONSERVATIVE
+        )
         self._balancer_algo = OptimisedLoadBalancer(
             max_limits=max_limits,
+            overcurrent_mode=overcurrent_mode,
         )
 
         self._power_allocator = PowerAllocator()

--- a/custom_components/evse_load_balancer/options_flow.py
+++ b/custom_components/evse_load_balancer/options_flow.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult, OptionsFlow
-from homeassistant.helpers.selector import NumberSelector
+from homeassistant.helpers.selector import BooleanSelector, NumberSelector
 
 from . import config_flow as cf
 from .exceptions.validation_exception import ValidationExceptionError
@@ -16,8 +16,12 @@ if TYPE_CHECKING:
 
 OPTION_CHARGE_LIMIT_HYSTERESIS = "charge_limit_hysteresis"
 OPTION_MAX_FUSE_LOAD_AMPS = "max_fuse_load_amps"
+OPTION_ALLOW_TEMPORARY_OVERCURRENT = "allow_temporary_overcurrent"
 
-DEFAULT_VALUES: dict[str, Any] = {OPTION_CHARGE_LIMIT_HYSTERESIS: 15}
+DEFAULT_VALUES: dict[str, Any] = {
+    OPTION_CHARGE_LIMIT_HYSTERESIS: 15,
+    OPTION_ALLOW_TEMPORARY_OVERCURRENT: True,
+}
 
 
 async def validate_init_input(
@@ -81,6 +85,13 @@ class EvseLoadBalancerOptionsFlow(OptionsFlow):
                         "unit_of_measurement": "A",
                     }
                 ),
+                vol.Optional(
+                    OPTION_ALLOW_TEMPORARY_OVERCURRENT,
+                    default=options_values.get(
+                        OPTION_ALLOW_TEMPORARY_OVERCURRENT,
+                        DEFAULT_VALUES[OPTION_ALLOW_TEMPORARY_OVERCURRENT],
+                    ),
+                ): BooleanSelector(),
             }
         )
 

--- a/custom_components/evse_load_balancer/strings.json
+++ b/custom_components/evse_load_balancer/strings.json
@@ -36,7 +36,11 @@
                 "title": "EVSE Load Balancer Options",
                 "data": {
                     "charge_limit_hysteresis": "Hysteresis (Minutes)",
-                    "max_fuse_load_amps": "Max Fuse Load Override (A)"
+                    "max_fuse_load_amps": "Max Fuse Load Override (A)",
+                    "allow_temporary_overcurrent": "Allow temporary overcurrent"
+                },
+                "data_description": {
+                    "allow_temporary_overcurrent": "When enabled, tolerates brief power spikes using risk-based algorithm. Disable for contracts with peak billing or strict overcurrent restrictions."
                 },
                 "description": "Adjust the behavior of the EVSE Load Balancer. For 'Max Fuse Load Override', a value of 0 means no override and the main fuse size will be used."
             }

--- a/custom_components/evse_load_balancer/translations/en.json
+++ b/custom_components/evse_load_balancer/translations/en.json
@@ -36,7 +36,11 @@
                 "title": "EVSE Load Balancer Options",
                 "data": {
                     "charge_limit_hysteresis": "Hysteresis (Minutes)",
-                    "max_fuse_load_amps": "Max Fuse Load Override (A)"
+                    "max_fuse_load_amps": "Max Fuse Load Override (A)",
+                    "allow_temporary_overcurrent": "Allow temporary overcurrent"
+                },
+                "data_description": {
+                    "allow_temporary_overcurrent": "When enabled, tolerates brief power spikes using risk-based algorithm. Disable for contracts with peak billing or strict overcurrent restrictions."
                 },
                 "description": "Adjust how many minutes the load balancer should wait before increasing a charger's limit. For 'Max Fuse Load Override', an empty value means no override and the initial main fuse size will be used."
             }

--- a/tests/balancers/test_optimised_load_balancer.py
+++ b/tests/balancers/test_optimised_load_balancer.py
@@ -1,5 +1,5 @@
 from custom_components.evse_load_balancer.balancers.optimised_load_balancer import OptimisedLoadBalancer, PhaseMonitor
-from custom_components.evse_load_balancer.const import Phase
+from custom_components.evse_load_balancer.const import OvercurrentMode, Phase
 
 
 def test_default_init():
@@ -61,3 +61,114 @@ def test_calculate_trip_risk():
     assert pm._calculate_trip_risk(-10) == 60.0 / 30
     assert pm._calculate_trip_risk(-15) == 60.0 / 10
     assert pm._calculate_trip_risk(-35) == 60.0
+
+
+def test_conservative_mode_init():
+    lb = OptimisedLoadBalancer(
+        max_limits=dict.fromkeys(Phase, 25),
+        overcurrent_mode=OvercurrentMode.CONSERVATIVE,
+    )
+    for controller in lb._phase_monitors:
+        assert isinstance(lb._phase_monitors[controller], PhaseMonitor)
+        assert lb._phase_monitors[controller]._overcurrent_mode == OvercurrentMode.CONSERVATIVE
+        assert lb._phase_monitors[controller].max_limit == 25
+        assert lb._phase_monitors[controller].phase_limit == 25
+
+
+def test_conservative_mode_immediate_reduction():
+    lb = OptimisedLoadBalancer(
+        max_limits=dict.fromkeys(Phase, 25),
+        overcurrent_mode=OvercurrentMode.CONSERVATIVE,
+    )
+    available_currents_one = {phase: 20 for phase in Phase}
+    available_currents_two = {phase: -5 for phase in Phase}
+    now = 100
+
+    limits_one = lb.compute_availability(available_currents_one, 0)
+    limits_two = lb.compute_availability(available_currents_two, now)
+
+    for phase in Phase:
+        assert limits_one[phase] == 20
+        assert limits_two[phase] == 15
+
+
+def test_conservative_mode_never_goes_below_zero():
+    lb = OptimisedLoadBalancer(
+        max_limits=dict.fromkeys(Phase, 25),
+        overcurrent_mode=OvercurrentMode.CONSERVATIVE,
+    )
+    available_currents_one = {phase: 5 for phase in Phase}
+    available_currents_two = {phase: -10 for phase in Phase}
+
+    limits_one = lb.compute_availability(available_currents_one, 0)
+    limits_two = lb.compute_availability(available_currents_two, 100)
+
+    for phase in Phase:
+        assert limits_one[phase] == 5
+        assert limits_two[phase] == 0
+
+
+def test_conservative_mode_allows_increases():
+    lb = OptimisedLoadBalancer(
+        max_limits=dict.fromkeys(Phase, 25),
+        overcurrent_mode=OvercurrentMode.CONSERVATIVE,
+    )
+    available_currents_one = {phase: 10 for phase in Phase}
+    available_currents_two = {phase: -5 for phase in Phase}
+    available_currents_three = {phase: 15 for phase in Phase}
+
+    limits_one = lb.compute_availability(available_currents_one, 0)
+    limits_two = lb.compute_availability(available_currents_two, 100)
+    limits_three = lb.compute_availability(available_currents_three, 200)
+
+    for phase in Phase:
+        assert limits_one[phase] == 10
+        assert limits_two[phase] == 5
+        assert limits_three[phase] == 15
+
+
+def test_conservative_mode_risk_not_accumulated():
+    lb = OptimisedLoadBalancer(
+        max_limits=dict.fromkeys(Phase, 25),
+        overcurrent_mode=OvercurrentMode.CONSERVATIVE,
+    )
+    available_currents = {phase: -2 for phase in Phase}
+
+    lb.compute_availability(available_currents, 0)
+    lb.compute_availability(available_currents, 10)
+    lb.compute_availability(available_currents, 20)
+
+    for phase in Phase:
+        assert lb._phase_monitors[phase]._cumulative_trip_risk == 0.0
+
+
+def test_optimised_mode_default_allows_temporary_overcurrent():
+    lb = OptimisedLoadBalancer(max_limits=dict.fromkeys(Phase, 25))
+    for controller in lb._phase_monitors:
+        assert lb._phase_monitors[controller]._overcurrent_mode == OvercurrentMode.OPTIMISED
+
+
+def test_conservative_vs_optimised_mode_behavior():
+    lb_conservative = OptimisedLoadBalancer(
+        max_limits=dict.fromkeys(Phase, 25),
+        overcurrent_mode=OvercurrentMode.CONSERVATIVE,
+    )
+    lb_optimised = OptimisedLoadBalancer(
+        max_limits=dict.fromkeys(Phase, 25),
+        overcurrent_mode=OvercurrentMode.OPTIMISED,
+    )
+
+    available_one = {phase: 20 for phase in Phase}
+    available_two = {phase: -3 for phase in Phase}
+
+    limits_conservative_one = lb_conservative.compute_availability(available_one, 0)
+    limits_optimised_one = lb_optimised.compute_availability(available_one, 0)
+
+    limits_conservative_two = lb_conservative.compute_availability(available_two, 5)
+    limits_optimised_two = lb_optimised.compute_availability(available_two, 5)
+
+    for phase in Phase:
+        assert limits_conservative_one[phase] == 20
+        assert limits_optimised_one[phase] == 20
+        assert limits_conservative_two[phase] == 17
+        assert limits_optimised_two[phase] == 20


### PR DESCRIPTION
Add option to disable temporary overcurrent tolerance for users with peak-based billing contracts or strict grid connection agreements.

Addresses #34

<img width="630" height="459" alt="image" src="https://github.com/user-attachments/assets/fb91ebcd-5e67-4e81-b892-388727ec7a5a" />
